### PR TITLE
@metamask/ethjs-query v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+# 0.4.0 -- maintenance update
+
+1. Renamed to @metamask/ethjs-query
+2. Fixed and removed broken devDependencies
+3. Require minimum nodejs v8.17, npm v6
+4. Repository location changed
+5. `npm prepublish` is now `npm prepare`
+
+# 0.3.8 -- performCall change
+
+1. Replace babel transforms with dependency babel-runtime
+2. performCall behaves differently
+
+
+# 0.3.7 -- various fixes
+1. Async and promise handling changes
+2. ethjs-rpc bump to 0.2.0
+3. Replaced ethereum-tesrpc with ganache-core
+
+# 0.3.6 -- ethjs-format bump to 0.2.7
+
 # 0.3.5 -- new eth filter ID changes
 
 1. Adds padded quantities

--- a/README.md
+++ b/README.md
@@ -1,17 +1,6 @@
 ## ethjs-query
 
 <div>
-  <!-- Dependency Status -->
-  <a href="https://david-dm.org/ethjs/ethjs-query">
-    <img src="https://david-dm.org/ethjs/ethjs-query.svg"
-    alt="Dependency Status" />
-  </a>
-
-  <!-- devDependency Status -->
-  <a href="https://david-dm.org/ethjs/ethjs-query#info=devDependencies">
-    <img src="https://david-dm.org/ethjs/ethjs-query/dev-status.svg" alt="devDependency Status" />
-  </a>
-
   <!-- NPM Version -->
   <a href="https://www.npmjs.org/package/ethjs-query">
     <img src="http://img.shields.io/npm/v/ethjs-query.svg"
@@ -67,7 +56,7 @@ This module supports all Ethereum RPC methods and is designed completely to spec
 
 `ethjs-query` uses the `ethjs-format` module to format incoming and outgoing RPC data payloads. The primary formatting task is numbers. Number values can be inputed as: `BigNumber`, `BN`, `string`, `hex` or `actual numbers`. Because the blockchain does not support decimal or negative numbers, any kind of decimal or negative number will cause an error return. All received number values are returned as BN.js object instances.
 
-Read more about the formatting layer here: [ethjs-format](http://github.com/ethjs/ethjs-format)
+Read more about the formatting layer here: [ethjs-format](http://github.com/MetaMask/ethjs-format)
 
 ## Async Only
 
@@ -205,13 +194,13 @@ There is always a lot of work to do, and will have many rules to maintain. So pl
 
 Please consult our [Code of Conduct](CODE_OF_CONDUCT.md) docs before helping out.
 
-We communicate via [issues](https://github.com/ethjs/ethjs-query/issues) and [pull requests](https://github.com/ethjs/ethjs-query/pulls).
+We communicate via [issues](https://github.com/MetaMask/ethjs-query/issues) and [pull requests](https://github.com/MetaMask/ethjs-query/pulls).
 
 ## Important documents
 
 - [Changelog](CHANGELOG.md)
 - [Code of Conduct](CODE_OF_CONDUCT.md)
-- [License](https://raw.githubusercontent.com/ethjs/ethjs-query/master/LICENSE)
+- [License](https://raw.githubusercontent.com/MetaMask/ethjs-query/master/LICENSE)
 
 ## Licence
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,7 @@ should not need to be touched.
 
 For more in-depth structure, see the developer-guide.md.
 
-*(If they do have to be changed, please [submit an issue](https://github.com/ethjs/ethjs-query/issues)!)*
+*(If they do have to be changed, please [submit an issue](https://github.com/MetaMask/ethjs-query/issues)!)*
 
 ### Testing
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -11,7 +11,7 @@ npm install --save ethjs-query
 ## Install from Source
 
 ```
-git clone http://github.com/ethjs/ethjs-query
+git clone http://github.com/MetaMask/ethjs-query
 npm install
 ```
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -56,7 +56,7 @@ eth.accounts(cb);
 
 `ethjs-query` uses the `ethjs-format` module to format incoming and outgoing RPC data payloads. The primary formatting task is numbers. Number values can be inputed as: `BigNumber`, `BN`, `string`, `hex` or `actual numbers`. Because the blockchain does not support decimal or negative numbers, any kind of decimal or negative number will cause an error return. All received number values are returned as BN.js object instances.
 
-Read more about the formatting layer here: [ethjs-format](http://github.com/ethjs/ethjs-format)
+Read more about the formatting layer here: [ethjs-format](http://github.com/MetaMask/ethjs-format)
 
 ## Async Only
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "ethjs-query",
-  "version": "0.3.8",
+  "name": "@metamask/ethjs-query",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "ethjs-query",
-  "version": "0.3.8",
+  "name": "@metamask/ethjs-query",
+  "version": "0.4.0",
   "description": "A simple query layer for the Ethereum RPC.",
   "main": "lib/index.js",
   "files": [
@@ -31,7 +31,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/ethjs/ethjs-query.git"
+    "url": "https://github.com/MetaMask/ethjs-query.git"
   },
   "keywords": [
     "ethereum",
@@ -46,9 +46,9 @@
   "author": "Nick Dodson <nick.dodson@consensys.net>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/ethjs/ethjs-query/issues"
+    "url": "https://github.com/MetaMask/ethjs-query/issues"
   },
-  "homepage": "https://github.com/ethjs/ethjs-query#readme",
+  "homepage": "https://github.com/MetaMask/ethjs-query#readme",
   "babel": {
     "plugins": [
       [


### PR DESCRIPTION
This is intended to be a safe maintenance release which produces an identical build to `v0.3.8`. It migrates CI to GHA and does the minimal changes to get install/build/test working again. Users of v0.3.8 should be able to upgrade safely.

* Bump version to v0.4.0
* Rename package to @metamask/ethjs-query
* Change repository URL to https://github.com/MetaMask/ethjs-query
* Update docs

### [v0.4.0 changes from v0.3.8](https://github.com/ethjs/ethjs-query/compare/master...legobt:ethjs-query:metamask-v0.4.0):

1. Renamed to `@metamask/ethjs-query`
2. Fixed and removed broken devDependencies (#2)
3. Require minimum nodejs v8.17, npm v6 (#4)
4. Repository location changed

Internal:
1. CI migrated from Travis to Github Actions (#1, #3)
2. `npm test-travis` is now `npm test:coverage` (#3)
3. Removed coveralls (#3)
4. `npm prepublish` is now `npm prepare` (#6)

