### PR TITLE
missing publishConfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,10 @@
     "type": "git",
     "url": "https://github.com/MetaMask/ethjs-query.git"
   },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
   "keywords": [
     "ethereum",
     "query",


### PR DESCRIPTION
## Missing publishConfig
We need the publishConfig added to package.json in order to properly publish this package. Copied from the module template.

Before opening a pull request, please ensure:

- [x] You have followed our [**contributing guidelines**](https://github.com/ethjs/ethjs-query/blob/master/.github/CONTRIBUTING.md)
- [x] Pull request has tests (we are going for 100% coverage!)
- [x] Code is well-commented, linted and follows project conventions
- [x] Documentation is updated (if necessary)
- [x] Internal code generators and templates are updated (if necessary)
- [x] Description explains the issue/use-case resolved and auto-closes related issues

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)

**IMPORTANT**: By submitting a patch, you agree to allow the project
owners to license your work under the terms of the [MIT License](https://github.com/ethjs/ethjs-query/blob/master/LICENSE.md).
