### PR TITLE
v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.5.0 -- change to error reporting
+
+1. Removed logic that was catching too broadly and applying an erroneous "formatting error" error.
+2. Removed logic that was rethrowing newly constructed Error objects that stripped stack traces relevant to the actual error. 
+3. Changes to lint configuration
+
 # 0.4.0 -- maintenance update
 
 1. Renamed to @metamask/ethjs-query

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/ethjs-query",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/ethjs-query",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "A simple query layer for the Ethereum RPC.",
   "main": "lib/index.js",
   "files": [


### PR DESCRIPTION
## v0.5.0

1. Removed logic that was catching too broadly and applying an erroneous "formatting error" error.
2. Removed logic that was rethrowing newly constructed Error objects that stripped stack traces relevant to the actual error. 
3. Changes to lint configuration