### PR TITLE
deps: @metamask/ethjs-format@^0.2.8->^0.2.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,9 +18,9 @@
       }
     },
     "@metamask/ethjs-rpc": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@metamask/ethjs-rpc/-/ethjs-rpc-0.3.1.tgz",
-      "integrity": "sha512-NT2KIsqTANj1prKseuazzfLhtHQtKiTOknCHylrShUyLW+8lLJUCaHQL1Y9XPg/1MQXYGBad7TShOXqGWX2kcg==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@metamask/ethjs-rpc/-/ethjs-rpc-0.3.0.tgz",
+      "integrity": "sha512-rS44jV/Ma4avG7ywDvnVaEr0dNU0lYk9IlcF1DL6fndwJJX72Bwp+T4iDO2+T/v1+wOaEw+r+StWCZYhwFObBw==",
       "requires": {
         "promise-to-callback": "^1.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
   },
   "dependencies": {
     "@metamask/ethjs-format": "^0.2.9",
-    "@metamask/ethjs-rpc": "^0.3.0",
+    "@metamask/ethjs-rpc": "^0.3.0 !0.3.1",
     "babel-runtime": "^6.26.0",
     "promise-to-callback": "^1.0.0"
   },


### PR DESCRIPTION
- Fully removes transitive dependency on ethjs-util without breaking changes
- Note that this is targeting `v0.5.x` (not `main`)


---

#### Blocking
- #37