### PR TITLE
[0.5.x] fix: dependency invalid semver range on yarn v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
   },
   "dependencies": {
     "@metamask/ethjs-format": "^0.2.9",
-    "@metamask/ethjs-rpc": "^0.3.0 !0.3.1",
+    "@metamask/ethjs-rpc": "0.3.0 || ^0.3.2",
     "babel-runtime": "^6.26.0",
     "promise-to-callback": "^1.0.0"
   },


### PR DESCRIPTION
The existing range for `@metamask/ethjs-rpc` of `^0.3.0 !0.3.1` isn't recognized by yarn v4, which results in the following error when including `@metamask/ethjs-query` as a dependency:

    YN0001: │ Error: @metamask/ethjs-rpc@^0.3.0 !0.3.1 isn't supported by any available resolver

This translates it into a recognized range by using a union instead of negation.

https://github.com/yarnpkg/berry/issues/1657

Validating using `semver`:

```
$ npx semver -r '^0.3.0 !0.3.1' 0.3.0 0.3.1 0.3.2 0.4.0

$ npx semver -r '0.3.0 || ^0.3.2' 0.3.0 0.3.1 0.3.2 0.4.0
0.3.0
0.3.2
```

---

#### Blocking
- https://github.com/MetaMask/metamask-extension/pull/21884