### PR TITLE
chore: add changelog entry for v0.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - Remove implicit peerDependency `babel-runtime` ([#10](https://github.com/MetaMask/ethjs-query/pull/10))
 
+## [0.5.3]
+### Fixed
+- Dependency range of `@metamask/ethjs-rpc` is now valid semver ([#40](https://github.com/MetaMask/ethjs-query/pull/40))
+  - This fixes an issues that affected yarn berry users.
+
 ## [0.5.2]
 ### Changed
 - Bump `@metamask/ethjs-format` from `^0.2.8` to `^0.2.9` ([#38](https://github.com/MetaMask/ethjs-query/pull/38))
@@ -182,7 +187,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [Unreleased]: https://github.com/MetaMask/ethjs-query/compare/v0.7.0...HEAD
 [0.7.0]: https://github.com/MetaMask/ethjs-query/compare/v0.6.0...v0.7.0
-[0.6.0]: https://github.com/MetaMask/ethjs-query/compare/v0.5.2...v0.6.0
+[0.6.0]: https://github.com/MetaMask/ethjs-query/compare/v0.5.3...v0.6.0
+[0.5.3]: https://github.com/MetaMask/ethjs-query/compare/v0.5.2...v0.5.3
 [0.5.2]: https://github.com/MetaMask/ethjs-query/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/MetaMask/ethjs-query/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/MetaMask/ethjs-query/compare/v0.4.0...v0.5.0


### PR DESCRIPTION
Add missing changelog entry for v0.5.3 release done from `v0.5.x` branch (#41)

#### Intended for
- #52
  - https://github.com/MetaMask/ethjs/pull/19